### PR TITLE
Updated README: Missing dependancy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@ Create a project. Then install the dpd-importer module.
 
     dpd create my-app
     cd my-app
-    mkdir node_modules
-    npm install dpd-importer
+    npm install shelljs dpd-importer
     dpd -d
     
 Click the green new resource and choose **Importer**.
 
-Give it the default name "/importer". Open it by clicking "IMPOTER" in the left menu.
+Give it the default name "/importer". Open it by clicking "IMPORTER" in the left menu.
 
 Enter the information of your old MongoDB server. Clicking on **Start Import** will start creating deployd collections from data in the provided db by streaming data directly from the old db into your new deployd db.
 


### PR DESCRIPTION
I installed as per the docs (non global install with npm) then ran 'dpd' in my deployd dir (which contains the node_modules dir) and I get this error output:

```
Error loading module node_modules/dpd-importer
Error: Cannot find module 'shelljs'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:362:17)
    at require (module.js:378:17)
    at Object.<anonymous> (/home/stefano/code/blah/node_modules/dpd-importer/index.js:3:10)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:362:17)
```

Update:
I discovered that 'shelljs' is just an npm module which is required for this one.
