### PR TITLE
Update mongodb driver version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Create a project. Then install the dpd-importer module.
     npm install dpd-importer
     dpd -d
     
+Create a collection(s) in your deployd dashboard to match that in your MongoDB database.
+
 Click the green new resource and choose **Importer**.
 
 Give it the default name "/importer". Open it by clicking "IMPORTER" in the left menu.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Ritchie Martori",
   "license": "BSD",
   "dependencies": {
-    "mongodb": "~1.1.11",
+    "mongodb": "^2.2.10",
     "shelljs": "~0.1.2"
   }
 }


### PR DESCRIPTION
I found that in attempting to import a MongoDB collection the following error in the CLI where I had run `dpd`

```
========================================================================================
=  Please ensure that you set the default safe variable to one of the                  =
=   allowed values of [true | false | {j:true} | {w:n, wtimeout:n} | {fsync:true}]     =
=   the default value is false which means the driver receives does not                =
=   return the information of the success/error of the insert/update/remove            =
=                                                                                      =
=   ex: new Db(new Server('localhost', 27017), {safe:false})                           =
=                                                                                      =
=   http://www.mongodb.org/display/DOCS/getLastError+Command                           =
=                                                                                      =
=  The default of false will change to true in the near future                         =
=                                                                                      =
=  This message will disappear when the default safe is set on the driver Db           =
========================================================================================
```

I think this is caused by a mismatch between version 2.x.x of the `mongodb` node package (i.e. the driver) used by [`deployed`](https://github.com/deployd/deployd/blob/master/package.json#L26) and the dependency version of the driver in `dpd-importer`.  Updating the dependency in `dpd-importer` solved this for me.

I also realise that in order to import a collection from a MongoDB server the `deployd` instance needs to have the same collection and properties present in the resources, or the import fails. So added this information to `readme`.
